### PR TITLE
Fix rerendering of reactNodes

### DIFF
--- a/packages/browser-extension/docs/TODO.md
+++ b/packages/browser-extension/docs/TODO.md
@@ -1,5 +1,9 @@
 # TODO
 
+- Improve collapsing to allow collapsing some children
+- When clicking highlight of collapsed entity, focus collapse indicator
+- drag border should supercede selected border
+
 - Translate sync to howdju graph/web
 - connect justifications using equivalent propositions
 - Auth using Chrome for now.

--- a/packages/browser-extension/src/graphView/ExtensionGraphView.tsx
+++ b/packages/browser-extension/src/graphView/ExtensionGraphView.tsx
@@ -1,5 +1,6 @@
-import React, { CSSProperties } from "react";
+import React, { CSSProperties, useCallback } from "react";
 
+import { MediaExcerpt } from "@sophistree/common";
 import { GraphView } from "@sophistree/ui-common";
 
 import { focusMediaExcerpt } from "./focusMediaExcerpt";
@@ -8,9 +9,11 @@ import {
   addNewProposition,
   completeDrag,
   deleteEntity,
+  DragPayload,
   resetSelection,
   selectEntities,
   toggleCollapsed,
+  useActiveMapAutomergeDocumentId,
   useSelectedEntityIds,
 } from "../store/entitiesSlice";
 import * as appLogger from "../logging/appLogging";
@@ -25,23 +28,59 @@ export default function ExtensionGraphView({
   style?: CSSProperties;
 }) {
   const dispatch = useAppDispatch();
+  const activeMapId = useActiveMapAutomergeDocumentId();
   const entities = useActiveMapEntities();
   const selectedEntityIds = useSelectedEntityIds();
   const outcomes = useActiveMapEntitiesOutcomes();
+
+  const onFocusMediaExcerpt = useCallback(
+    (me: MediaExcerpt) => void focusMediaExcerpt(me),
+    [],
+  );
+  const onSelectEntities = useCallback(
+    (ids: string[]) => dispatch(selectEntities(ids)),
+    [dispatch],
+  );
+  const onResetSelection = useCallback(
+    () => dispatch(resetSelection()),
+    [dispatch],
+  );
+  const onAddNewProposition = useCallback(
+    () => dispatch(addNewProposition()),
+    [dispatch],
+  );
+  const onDeleteEntity = useCallback(
+    (id: string) => dispatch(deleteEntity(id)),
+    [dispatch],
+  );
+  const onCompleteDrag = useCallback(
+    (ids: DragPayload) => dispatch(completeDrag(ids)),
+    [dispatch],
+  );
+  const onToggleCollapse = useCallback(
+    (id: string) => dispatch(toggleCollapsed(id)),
+    [dispatch],
+  );
+
+  if (!activeMapId) {
+    return "loading";
+  }
+
   return (
     <GraphView
-      style={style}
+      activeGraphId={activeMapId}
       entities={entities}
       selectedEntityIds={selectedEntityIds}
       outcomes={outcomes}
       logger={appLogger}
-      onFocusMediaExcerpt={(me) => void focusMediaExcerpt(me)}
-      onSelectEntities={(ids) => dispatch(selectEntities(ids))}
-      onResetSelection={() => dispatch(resetSelection())}
-      onAddNewProposition={() => dispatch(addNewProposition())}
-      onDeleteEntity={(id) => dispatch(deleteEntity(id))}
-      onCompleteDrag={(ids) => dispatch(completeDrag(ids))}
-      onToggleCollapse={(id) => dispatch(toggleCollapsed(id))}
+      onFocusMediaExcerpt={onFocusMediaExcerpt}
+      onSelectEntities={onSelectEntities}
+      onResetSelection={onResetSelection}
+      onAddNewProposition={onAddNewProposition}
+      onDeleteEntity={onDeleteEntity}
+      onCompleteDrag={onCompleteDrag}
+      onToggleCollapse={onToggleCollapse}
+      style={style}
     />
   );
 }

--- a/packages/browser-extension/src/store/entitiesSlice.ts
+++ b/packages/browser-extension/src/store/entitiesSlice.ts
@@ -33,7 +33,7 @@ import { createAppSlice } from "./createAppSlice";
 
 export const defaultVisibilityProps = { autoVisibility: "Visible" as const };
 
-interface DragPayload {
+export interface DragPayload {
   sourceId: string;
   targetId: string;
   polarity?: Polarity;

--- a/packages/ui-common/src/graphView/GraphView.tsx
+++ b/packages/ui-common/src/graphView/GraphView.tsx
@@ -39,6 +39,8 @@ cytoscape.use(reactNodes);
 
 interface GraphViewProps {
   id?: string;
+  // A unique identifier of the active map. Changing it resets the reactNodes extension.
+  activeGraphId: string;
   style?: CSSProperties;
   entities: Entity[];
   selectedEntityIds: string[];
@@ -55,6 +57,7 @@ interface GraphViewProps {
 
 export default function GraphView({
   id,
+  activeGraphId,
   style,
   entities,
   selectedEntityIds,
@@ -94,6 +97,7 @@ export default function GraphView({
 
   useReactNodes(
     cyRef,
+    activeGraphId,
     setVisitAppearancesDialogProposition,
     onFocusMediaExcerpt,
     onToggleCollapse,

--- a/packages/ui-common/src/graphView/useReactNodes.tsx
+++ b/packages/ui-common/src/graphView/useReactNodes.tsx
@@ -15,6 +15,7 @@ import { OnToggleCollapse } from "./collapsing";
 
 export function useReactNodes(
   cyRef: MutableRefObject<cytoscape.Core | undefined>,
+  activeGraphId: string,
   setVisitAppearancesDialogProposition: (
     data: PropositionNodeData | undefined,
   ) => void,
@@ -119,13 +120,19 @@ export function useReactNodes(
     if (cyRef.current) {
       const cy = cyRef.current;
 
-      cy.reactNodes({
-        layoutOptions: getLayout(false),
+      return cy.reactNodes({
+        layoutOptions: getLayout(true),
         nodes: reactNodesConfig,
         logger,
       });
     }
-  }, [cyRef, reactNodesConfig, logger]);
+  }, [
+    cyRef,
+    // Explicitly include activeGraphId so that a new map's nodes trigger relayout
+    activeGraphId,
+    reactNodesConfig,
+    logger,
+  ]);
 }
 
 const syncClasses = ["hover-highlight", "dragging", ...nodeOutcomeClasses];

--- a/packages/web-app/src/app/argument-maps/[id]/WebGraphView.tsx
+++ b/packages/web-app/src/app/argument-maps/[id]/WebGraphView.tsx
@@ -12,10 +12,12 @@ const logger = {
 
 export default function WebGraphView({
   id,
+  activeGraphId,
   style,
   entities,
 }: {
   id: string;
+  activeGraphId: string;
   style: CSSProperties;
   entities: Entity[];
 }) {
@@ -63,6 +65,7 @@ export default function WebGraphView({
     <div style={{ width: "100%", height: "100vh" }}>
       <GraphView
         id={id}
+        activeGraphId={activeGraphId}
         style={style}
         entities={entitiesWithCollapse}
         selectedEntityIds={selectedEntityIds}

--- a/packages/web-app/src/app/argument-maps/[id]/page.tsx
+++ b/packages/web-app/src/app/argument-maps/[id]/page.tsx
@@ -19,6 +19,7 @@ export default function ArgumentMapPage() {
   const params = useParams();
   const id = params.id as string;
 
+  const [mapId, setMapId] = useState<string>("");
   const [mapName, setMapName] = useState<string>("");
   const [entities, setEntities] = useState<Entity[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -31,6 +32,7 @@ export default function ArgumentMapPage() {
           throw new Error(`Failed to fetch map data: ${response.status}`);
         }
         const data = await response.json();
+        setMapId(data.id);
         setMapName(data.name);
         setEntities(data.entities);
       } catch (error) {
@@ -51,6 +53,7 @@ export default function ArgumentMapPage() {
       ) : (
         <WebGraphView
           id={id}
+          activeGraphId={mapId}
           style={{ width: "100%", height: "100%" }}
           entities={entities}
         />


### PR DESCRIPTION
- Adds useCallback to ExtensionGraphView to prevent unnecessary rerenders
- Adds relayout cutoff to reactNodes to try to create a layout after React nodes have positions.
- Cleanup reactNodes extension since we intentionally recreate it when there's a new active graph.