### PR TITLE
Fix tooltip layout on web-app and avatar space in extension

### DIFF
--- a/packages/ui-common/src/components/ArgumentMapCard.tsx
+++ b/packages/ui-common/src/components/ArgumentMapCard.tsx
@@ -16,6 +16,7 @@ import type { Logger } from "@sophistree/common";
 
 import { getOutcomeColorStyle } from "../outcomes/outcomeColors";
 import { DateTime } from "luxon";
+import { Props as CardTitleProps } from "react-native-paper/lib/typescript/components/Card/CardTitle";
 
 export interface ArgumentMapCardProps {
   map: ArgumentMapCardInfo;
@@ -78,6 +79,14 @@ export function ArgumentMapCard({
     [updatedAt],
   );
 
+  const leftAvatarProps = userInfo && {
+    left: ((props) => (
+      <Tooltip title={`Published by ${userInfo.displayName}`}>
+        <UserAvatar {...userInfo} {...props} />
+      </Tooltip>
+    )) as CardTitleProps["left"],
+  };
+
   return (
     <Card style={{ marginTop: 16 }}>
       <Card.Title
@@ -115,13 +124,7 @@ export function ArgumentMapCard({
             )}
           </>
         }
-        left={(props) =>
-          userInfo && (
-            <Tooltip title={`Published by ${userInfo.displayName}`}>
-              <UserAvatar {...userInfo} {...props} />
-            </Tooltip>
-          )
-        }
+        {...leftAvatarProps}
       />
 
       <Card.Content>

--- a/packages/web-app/src/app/layout.tsx
+++ b/packages/web-app/src/app/layout.tsx
@@ -19,7 +19,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en" style={{ height: "100%" }}>
+    <html lang="en">
       <style jsx global>{`
         html {
           font-family: ${roboto.style.fontFamily};
@@ -31,8 +31,11 @@ export default function RootLayout({
         [style*="font-family: MaterialCommunityIcons;"] {
           font-family: ${materialCommunityIcons.style.fontFamily} !important;
         }
+        [data-testid="tooltip-container"] {
+          position: fixed;
+        }
       `}</style>
-      <body style={{ height: "100%", margin: 0 }}>
+      <body style={{ margin: 0 }}>
         <Providers>{children}</Providers>
       </body>
     </html>

--- a/packages/web-app/src/app/providers.tsx
+++ b/packages/web-app/src/app/providers.tsx
@@ -4,9 +4,5 @@ import React from "react";
 import { PaperProvider } from "react-native-paper";
 
 export function Providers({ children }: { children: React.ReactNode }) {
-  return (
-    <PaperProvider>
-      <div style={{ height: "100vh" }}>{children}</div>
-    </PaperProvider>
-  );
+  return <PaperProvider>{children}</PaperProvider>;
 }


### PR DESCRIPTION
Fix tooltip layout on web-app map list; remove avatar space from extension map list.

I had this problem with Tooltips: https://github.com/callstack/react-native-paper/issues/4107#issuecomment-2670591966

While troubleshooting, I removed several layout styles (100%, 100vh) which turned out to be unnecessary.