### PR TITLE
Fix map deletion and useAllDocs

### DIFF
--- a/packages/browser-extension/src/App.tsx
+++ b/packages/browser-extension/src/App.tsx
@@ -49,6 +49,7 @@ import { GestureHandlerRootView } from "./bottomsheet-setup";
 import AppContainer from "./components/AppContainer";
 
 import "./App.scss";
+import { useBroadcastListener } from "./sync/broadcast";
 
 const App: React.FC = () => {
   const dispatch = useAppDispatch();
@@ -59,6 +60,7 @@ const App: React.FC = () => {
   useContentScriptKeepAliveConnection();
   useRefreshAuth();
   useSyncApiConfig();
+  useBroadcastListener();
 
   // Load initial configs
   useEffect(() => {

--- a/packages/browser-extension/src/components/OptionsPage.tsx
+++ b/packages/browser-extension/src/components/OptionsPage.tsx
@@ -5,9 +5,11 @@ import { useRefreshAuth } from "../store/hooks";
 import { AuthenticationCard } from "./AuthenticationCard";
 import { ApiEndpointOverrideSetting } from "./ApiEndpointOverrideSetting";
 import { DefaultSyncServerSettings } from "./DefaultSyncServerSettings";
+import { useBroadcastListener } from "../sync/broadcast";
 
 export function OptionsPage() {
   useRefreshAuth();
+  useBroadcastListener();
 
   return (
     <View style={{ maxWidth: 800, marginHorizontal: "auto", padding: 32 }}>

--- a/packages/browser-extension/src/store/entitiesSlice.ts
+++ b/packages/browser-extension/src/store/entitiesSlice.ts
@@ -29,6 +29,10 @@ import {
   openDoc,
   setDocSyncServerAddresses,
 } from "../sync";
+import {
+  broadcastDocDeletion,
+  broadcastMapActivation,
+} from "../sync/broadcast";
 import { addHistoryEntry } from "./addHistoryEntry";
 import { updateConclusions } from "./conclusions";
 import { createAppSlice } from "./createAppSlice";
@@ -37,7 +41,6 @@ import {
   getJustificationTargetHistoryInfo,
   toHistoryInfo,
 } from "./historyInfo";
-import { broadcastDocDelete, broadcastMapActivation } from "../sync/broadcast";
 
 export const defaultVisibilityProps = { autoVisibility: "Visible" as const };
 
@@ -93,7 +96,7 @@ export const entitiesSlice = createAppSlice({
     }),
     deleteMap: create.reducer<DocumentId>((state, action) => {
       deleteDoc(action.payload);
-      broadcastDocDelete(action.payload);
+      broadcastDocDeletion(action.payload);
       if (state.activeMapAutomergeDocumentId === action.payload) {
         state.activeMapAutomergeDocumentId = undefined;
       }

--- a/packages/browser-extension/src/sync/broadcast.ts
+++ b/packages/browser-extension/src/sync/broadcast.ts
@@ -16,7 +16,7 @@ import {
 // This channel can also notify other instances of UI changes, like activating the map.
 const broadcastChannel = new BroadcastChannel("sophistree-broadcast");
 
-export function broadcastDocDelete(id: DocumentId) {
+export function broadcastDocDeletion(id: DocumentId) {
   broadcastChannel.postMessage({
     type: "delete-document",
     id,

--- a/packages/browser-extension/src/sync/broadcast.ts
+++ b/packages/browser-extension/src/sync/broadcast.ts
@@ -1,0 +1,62 @@
+import { DocumentId } from "@automerge/automerge-repo";
+import { deleteDoc } from "./sync";
+import { useEffect } from "react";
+import { useAppDispatch } from "../store";
+import {
+  observeMapActivation,
+  observeMapDeletion,
+} from "../store/entitiesSlice";
+
+// BroadcastChannelNetworkAdapter keeps side panels in different windows in
+// sync, but they don't know when one of them deletes. In fact they sync
+// back deleted documents to the panel that deleted them after a reload.
+// So use a separate BroadcastChannel to broadcast deletes to ensure that
+// all copies are deleted.
+//
+// This channel can also notify other instances of UI changes, like activating the map.
+const broadcastChannel = new BroadcastChannel("sophistree-broadcast");
+
+export function broadcastDocDelete(id: DocumentId) {
+  broadcastChannel.postMessage({
+    type: "delete-document",
+    id,
+  } as DeleteDocumentMessage);
+}
+
+export function broadcastMapActivation(id: DocumentId | undefined) {
+  broadcastChannel.postMessage({
+    type: "activate-map",
+    id,
+  } as ActivateMapMessage);
+}
+
+export function useBroadcastListener() {
+  const dispatch = useAppDispatch();
+  useEffect(() => {
+    const listener = ({ data }: MessageEvent<BroadcastMessage>) => {
+      switch (data.type) {
+        case "delete-document":
+          deleteDoc(data.id);
+          dispatch(observeMapDeletion(data.id));
+          break;
+        case "activate-map":
+          dispatch(observeMapActivation(data.id));
+          break;
+      }
+    };
+    broadcastChannel.addEventListener("message", listener);
+    return () => {
+      broadcastChannel.removeEventListener("message", listener);
+    };
+  });
+}
+
+interface DeleteDocumentMessage {
+  type: "delete-document";
+  id: DocumentId;
+}
+interface ActivateMapMessage {
+  type: "activate-map";
+  id: DocumentId | undefined;
+}
+type BroadcastMessage = DeleteDocumentMessage | ActivateMapMessage;

--- a/packages/browser-extension/src/sync/hooks.ts
+++ b/packages/browser-extension/src/sync/hooks.ts
@@ -42,6 +42,7 @@ export const useAllMaps = () => {
     function addListener(handle: DocHandle<ArgumentMap>) {
       const listener = ({ doc }: DocHandleChangePayload<ArgumentMap>) => {
         setMaps((prevMaps) =>
+          // Compare id because when we first create a map it has no automergeDocumentId.
           prevMaps.map((prevMap) => (prevMap.id === doc.id ? doc : prevMap)),
         );
       };

--- a/packages/browser-extension/src/sync/migrations.ts
+++ b/packages/browser-extension/src/sync/migrations.ts
@@ -21,7 +21,7 @@ export function triggerMigrationIfNecessary(handle: DocHandle<ArgumentMap>) {
 async function ensureMapMigrations(handle: DocHandle<ArgumentMap>) {
   const doc = await handle.doc();
   if (!doc) {
-    throw new Error("Unable to get doc for migration");
+    throw new Error(`Unable to get doc for migration: ${handle.documentId}`);
   }
   let currentVersion = doc.version || minAutomergeMapVersion;
   if (currentVersion < persistedStateVersion) {

--- a/packages/browser-extension/src/sync/sync.ts
+++ b/packages/browser-extension/src/sync/sync.ts
@@ -13,7 +13,7 @@ import {
   getSyncServerAddresses,
   setSyncServerAddresses,
 } from "./syncServerStorage";
-import { broadcastDocDelete } from "./broadcast";
+import { broadcastDocDeletion } from "./broadcast";
 
 export function createDoc(map: NewArgumentMap) {
   const repo = getRepo([]);
@@ -72,7 +72,7 @@ export function setDocSyncServerAddresses(
   triggerMigrationIfNecessary(oldHandle);
   const doc = oldHandle.docSync();
   oldRepo.delete(oldId);
-  broadcastDocDelete(oldId);
+  broadcastDocDeletion(oldId);
 
   const newRepo = getRepo(syncServerAddresses);
   const handle = newRepo.create<ArgumentMap>(doc);

--- a/packages/browser-extension/src/sync/sync.ts
+++ b/packages/browser-extension/src/sync/sync.ts
@@ -7,12 +7,13 @@ import { getActorId } from "@automerge/automerge/next";
 
 import { ArgumentMap } from "@sophistree/common";
 
+import { triggerMigrationIfNecessary } from "./migrations";
+import { getRepo } from "./repos";
 import {
   getSyncServerAddresses,
   setSyncServerAddresses,
 } from "./syncServerStorage";
-import { getRepo } from "./repos";
-import { triggerMigrationIfNecessary } from "./migrations";
+import { broadcastDocDelete } from "./broadcast";
 
 export function createDoc(map: NewArgumentMap) {
   const repo = getRepo([]);
@@ -67,7 +68,12 @@ export function setDocSyncServerAddresses(
   syncServerAddresses: string[],
 ) {
   const oldRepo = getRepoForDoc(oldId);
-  const doc = oldRepo.find<ArgumentMap>(oldId).docSync();
+  const oldHandle = oldRepo.find<ArgumentMap>(oldId);
+  triggerMigrationIfNecessary(oldHandle);
+  const doc = oldHandle.docSync();
+  oldRepo.delete(oldId);
+  broadcastDocDelete(oldId);
+
   const newRepo = getRepo(syncServerAddresses);
   const handle = newRepo.create<ArgumentMap>(doc);
   const newId = handle.documentId;
@@ -90,10 +96,7 @@ export function setDocSyncServerAddresses(
       ],
     });
   });
-  oldRepo.delete(oldId);
   setSyncServerAddresses(newId, syncServerAddresses, oldId);
-
-  triggerMigrationIfNecessary(handle);
 
   return newId;
 }


### PR DESCRIPTION
If we want side panels in multiple windows to be consistent (open same document with same changes), then we must use a `BroadcastChannelNetworkAdapter`. But that adapter will restore deleted docs, so we must also broadcast deletes. We can use the same broadcast mechanism to delete map activations to keep the panel UIs in sync.