### PR TITLE
Fix useAllDocs for uploaded maps

### DIFF
--- a/packages/browser-extension/.eslintrc.js
+++ b/packages/browser-extension/.eslintrc.js
@@ -25,5 +25,15 @@ module.exports = {
   },
   rules: {
     "@typescript-eslint/switch-exhaustiveness-check": "error",
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      {
+        argsIgnorePattern: "^_",
+        caughtErrors: "all",
+        caughtErrorsIgnorePattern: "^_",
+        destructuredArrayIgnorePattern: "^_",
+        varsIgnorePattern: "^_",
+      },
+    ],
   },
 };

--- a/packages/browser-extension/src/store/entitiesSlice.ts
+++ b/packages/browser-extension/src/store/entitiesSlice.ts
@@ -80,11 +80,13 @@ export const entitiesSlice = createAppSlice({
   },
   reducers: (create) => ({
     createMap: create.reducer<Partial<ArgumentMap>>((state, action) => {
+      // Don't allow callers to set the automerge document ID (e.g. uploaded files.)
+      const { automergeDocumentId: _, ...createData } = action.payload;
       const newMap: NewArgumentMap = {
         name: "New map",
         entities: [],
         conclusions: [],
-        ...action.payload,
+        ...createData,
         // Overwrite any ID from the payload to ensure that uploaded maps do not replace existing ones.
         id: uuidv4(),
         sourceNameOverrides: {},

--- a/packages/browser-extension/src/sync/repos.ts
+++ b/packages/browser-extension/src/sync/repos.ts
@@ -81,7 +81,7 @@ export function getRepo(syncServerAddresses: string[]) {
     repo = makeRemoteRepo(syncServerAddresses);
     void persistStorage();
     reposBySyncServers.set(key, repo);
-    applyCallbacksToRepo(repo);
+    addCallbacksToRepo(repo);
   }
   return repo;
 }
@@ -118,7 +118,7 @@ export type DocChangeListener = (
   payload: DocumentPayload | DeleteDocumentPayload,
 ) => void;
 
-export function addDocChangeListener(callback: DocChangeListener) {
+export function addRepoDocChangeListener(callback: DocChangeListener) {
   docChangeListeners.add(callback);
   reposBySyncServers.values().forEach((r) => {
     r.on("document", callback);
@@ -126,7 +126,7 @@ export function addDocChangeListener(callback: DocChangeListener) {
   });
 }
 
-export function removeDocChangeListener(callback: DocChangeListener) {
+export function removeRepoDocChangeListener(callback: DocChangeListener) {
   docChangeListeners.delete(callback);
   reposBySyncServers.values().forEach((r) => {
     r.off("document", callback);
@@ -134,7 +134,7 @@ export function removeDocChangeListener(callback: DocChangeListener) {
   });
 }
 
-function applyCallbacksToRepo(repo: Repo) {
+function addCallbacksToRepo(repo: Repo) {
   docChangeListeners.forEach((callback) => {
     repo.on("document", callback);
     repo.on("delete-document", callback);

--- a/packages/browser-extension/src/sync/sync.ts
+++ b/packages/browser-extension/src/sync/sync.ts
@@ -20,17 +20,19 @@ export function createDoc(map: NewArgumentMap) {
   const handle = repo.create(map);
   handle.change((map) => {
     map.automergeDocumentId = handle.documentId;
-    map.history.push({
-      actorId: getActorId(map),
-      heads: handle.heads(),
-      timestamp: new Date().toISOString(),
-      changes: [
-        {
-          type: "CreateMap",
-          name: map.name,
-        },
-      ],
-    });
+    map.history = [
+      {
+        actorId: getActorId(map),
+        heads: handle.heads(),
+        timestamp: new Date().toISOString(),
+        changes: [
+          {
+            type: "CreateMap",
+            name: map.name,
+          },
+        ],
+      },
+    ];
   });
   return handle;
 }


### PR DESCRIPTION
Don't call updateMapInList in a timeout. Otherwise the callbacks appear to get out of order and automergeDocumentId is overwritten to be missing. Otherwise mostly renames for clarity.